### PR TITLE
feature: 페이징 응답 데이터 수정

### DIFF
--- a/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomController.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomController.java
@@ -5,6 +5,7 @@ import com.umc7.ZIC.apiPayload.code.status.ErrorStatus;
 import com.umc7.ZIC.apiPayload.exception.ApiResponse;
 import com.umc7.ZIC.apiPayload.exception.handler.UserHandler;
 import com.umc7.ZIC.practiceRoom.dto.PageRequestDto;
+import com.umc7.ZIC.practiceRoom.dto.PageResponseDto;
 import com.umc7.ZIC.practiceRoom.dto.PracticeRoomRequestDto;
 import com.umc7.ZIC.practiceRoom.dto.PracticeRoomResponseDto;
 import com.umc7.ZIC.practiceRoom.service.PracticeRoomService;
@@ -80,9 +81,9 @@ public class PracticeRoomController {
 
     //연습실 리스트 조회
     @GetMapping
-    @Operation(summary = "연습실을 리스트 형식으로조회할때 사용하는 API", description = "PracticeRoomId로 연습실을 리스트 형식으로 조회할 때 사용하는 API")
-    public ApiResponse<Page<PracticeRoomResponseDto.GetResponseDto>> getPracticeRoomList(@ModelAttribute PageRequestDto request) {
-        Page<PracticeRoomResponseDto.GetResponseDto> response = practiceRoomService.getPracticeRoomList(request);
+    @Operation(summary = "연습실을 목록(페이징) 형식으로조회할때 사용하는 API", description = "PracticeRoomId로 연습실을 목록(페이징) 형식으로 조회할 때 사용하는 API")
+    public ApiResponse<PageResponseDto<PracticeRoomResponseDto.GetResponseDto>> getPracticeRoomList(@ModelAttribute PageRequestDto request) {
+        PageResponseDto<PracticeRoomResponseDto.GetResponseDto> response = practiceRoomService.getPracticeRoomList(request);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomDetailController.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomDetailController.java
@@ -3,10 +3,7 @@ package com.umc7.ZIC.practiceRoom.controller;
 import com.umc7.ZIC.apiPayload.code.status.ErrorStatus;
 import com.umc7.ZIC.apiPayload.exception.ApiResponse;
 import com.umc7.ZIC.apiPayload.exception.handler.UserHandler;
-import com.umc7.ZIC.practiceRoom.dto.AvailableTimeSlot;
-import com.umc7.ZIC.practiceRoom.dto.PageRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailResponseDto;
+import com.umc7.ZIC.practiceRoom.dto.*;
 import com.umc7.ZIC.practiceRoom.service.PracticeRoomDetailService;
 import com.umc7.ZIC.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,11 +46,11 @@ public class PracticeRoomDetailController {
 
     //연습실 내부 방 목록 조회
     @GetMapping
-    @Operation(summary = "연습실 내부 방 목록 조회 API", description = "연습실 내부 방 목록을 조회하는API.")
-    public ApiResponse<Page<PracticeRoomDetailResponseDto.GetDetailResponseDto>> getPracticeRoomDetailList(
+    @Operation(summary = "연습실 내부 방 목록(페이징) 조회 API", description = "연습실 내부 방 목록을 조회하는API.")
+    public ApiResponse<PageResponseDto<PracticeRoomDetailResponseDto.GetDetailResponseDto>> getPracticeRoomDetailList(
             @ModelAttribute PageRequestDto request,
             @RequestParam("practiceRoomId") Long practiceRoomId) {
-        Page<PracticeRoomDetailResponseDto.GetDetailResponseDto> response = practiceRoomDetailService.getPracticeRoomDetailList(request, practiceRoomId);
+        PageResponseDto<PracticeRoomDetailResponseDto.GetDetailResponseDto> response = practiceRoomDetailService.getPracticeRoomDetailList(request, practiceRoomId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/umc7/ZIC/practiceRoom/dto/PageResponseDto.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/dto/PageResponseDto.java
@@ -2,19 +2,25 @@ package com.umc7.ZIC.practiceRoom.dto;
 
 import org.springframework.data.domain.Page;
 
-public record PageResponseDto(
-        Integer totalPages, // 전체 페이지 수
-        Integer currentPage, // 현재 페이지 번호 (1부터 시작)
-        Long totalElements, // 전체 요소 개수
-        Integer currentSize // 현재 페이지의 요소 개수
+import java.util.List;
+
+public record PageResponseDto<T>(
+        List<T> resultList,   // 실제 데이터 목록
+        Integer listSize,    // 현재 페이지의 데이터 개수
+        Integer totalPage,  // 전체 페이지 수
+        Long totalElements,  // 전체 요소 개수 (모든페이지를 합한수)
+        Boolean isFirst,      // 현재 페이지가 첫 페이지인지 여부
+        Boolean isLast       // 현재 페이지가 마지막 페이지인지 여부
 ) {
 
-    public static PageResponseDto from(Page<?> page) {
-        return new PageResponseDto(
-                page.getTotalPages(),
-                page.getNumber() + 1, // 0-based index이므로 1을 더함
-                page.getTotalElements(),
-                page.getNumberOfElements()
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return new PageResponseDto<>(
+                page.getContent(),      // 데이터 목록
+                page.getNumberOfElements(), // 현재 페이지의 요소 개수
+                page.getTotalPages(),       // 전체 페이지 수
+                page.getTotalElements(),    // 전체 요소 개수
+                page.isFirst(),         // 현재 페이지가 첫 페이지인지 여부
+                page.isLast()          // 현재 페이지가 마지막 페이지인지 여부
         );
     }
 }

--- a/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomDetailService.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomDetailService.java
@@ -1,9 +1,6 @@
 package com.umc7.ZIC.practiceRoom.service;
 
-import com.umc7.ZIC.practiceRoom.dto.AvailableTimeSlot;
-import com.umc7.ZIC.practiceRoom.dto.PageRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailResponseDto;
+import com.umc7.ZIC.practiceRoom.dto.*;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
@@ -12,7 +9,7 @@ import java.util.List;
 
 public interface PracticeRoomDetailService {
     PracticeRoomDetailResponseDto.CreateDetailResponseDto createPracticeRoomDetail(PracticeRoomDetailRequestDto.CreateRequestDetailDto createRequest, Long practiceRoomId, Long userId);
-    Page<PracticeRoomDetailResponseDto.GetDetailResponseDto> getPracticeRoomDetailList(PageRequestDto request, Long practiceRoomId);
+    PageResponseDto<PracticeRoomDetailResponseDto.GetDetailResponseDto> getPracticeRoomDetailList(PageRequestDto request, Long practiceRoomId);
     PracticeRoomDetailResponseDto.GetDetailResponseDto getPracticeRoomDetail(Long practiceRoomDetailId);
     PracticeRoomDetailResponseDto.UpdateDetailResponseDto updatePracticeRoomDetail(PracticeRoomDetailRequestDto.UpdateRequestDetailDto updateRequest, Long practiceRoomDetailId, Long userId);
     void deletePracticeRoomDetail(Long practiceRoomDetailId, Long userId);

--- a/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomDetailServiceImpl.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomDetailServiceImpl.java
@@ -6,10 +6,7 @@ import com.umc7.ZIC.apiPayload.exception.handler.PracticeRoomHandler;
 import com.umc7.ZIC.apiPayload.exception.handler.UserHandler;
 import com.umc7.ZIC.practiceRoom.domain.PracticeRoom;
 import com.umc7.ZIC.practiceRoom.domain.PracticeRoomDetail;
-import com.umc7.ZIC.practiceRoom.dto.AvailableTimeSlot;
-import com.umc7.ZIC.practiceRoom.dto.PageRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailRequestDto;
-import com.umc7.ZIC.practiceRoom.dto.PracticeRoomDetailResponseDto;
+import com.umc7.ZIC.practiceRoom.dto.*;
 import com.umc7.ZIC.practiceRoom.repository.PracticeRoomDetailRepository;
 import com.umc7.ZIC.practiceRoom.repository.PracticeRoomRepository;
 import com.umc7.ZIC.reservation.domain.Reservation;
@@ -63,15 +60,21 @@ public class PracticeRoomDetailServiceImpl implements PracticeRoomDetailService 
 
     //연습실 내부 방 목록 조회
     @Override
-    public Page<PracticeRoomDetailResponseDto.GetDetailResponseDto> getPracticeRoomDetailList(PageRequestDto request, Long practiceRoomId) {
+    public PageResponseDto<PracticeRoomDetailResponseDto.GetDetailResponseDto> getPracticeRoomDetailList(PageRequestDto request, Long practiceRoomId) {
 
+        //연습실이 있는지 확인
         PracticeRoom practiceRoom = practiceRoomRepository.findById(practiceRoomId)
                 .orElseThrow(() -> new PracticeRoomHandler(ErrorStatus.PRACTICEROOM_NOT_FOUND));
 
+        //PageRequestDto 객체로부터 Pageable 객체를 생성
         Pageable pageable = request.toPageable();
         Page<PracticeRoomDetail> practiceRoomDetailPage = practiceRoomDetailRepository.findAllByPracticeRoomId(practiceRoomId, pageable);
 
-        return practiceRoomDetailPage.map(PracticeRoomDetailResponseDto.GetDetailResponseDto::from);
+        // 조회된 내부 방 목록(Page<PracticeRoomDetail>)을 DTO 목록(Page<PracticeRoomDetailResponseDto.GetDetailResponseDto>)으로 변환.
+        Page<PracticeRoomDetailResponseDto.GetDetailResponseDto> practiceRoomDetailDtoPage = practiceRoomDetailPage.map(PracticeRoomDetailResponseDto.GetDetailResponseDto::from);
+
+        //DTO 목록(Page<DTO>)을 최종 응답 객체(PageResponseDto<DTO>)로 변환하여 반환.
+        return PageResponseDto.from(practiceRoomDetailDtoPage);
     }
 
     //연습실 단일 조회

--- a/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomService.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomService.java
@@ -1,6 +1,7 @@
 package com.umc7.ZIC.practiceRoom.service;
 
 import com.umc7.ZIC.practiceRoom.dto.PageRequestDto;
+import com.umc7.ZIC.practiceRoom.dto.PageResponseDto;
 import com.umc7.ZIC.practiceRoom.dto.PracticeRoomRequestDto;
 import com.umc7.ZIC.practiceRoom.dto.PracticeRoomResponseDto;
 import org.springframework.data.domain.Page;
@@ -16,5 +17,5 @@ public interface PracticeRoomService {
     // 연습실 단일 조회
     PracticeRoomResponseDto.GetResponseDto getPracticeRoom(Long practiceRoomId);
     // 연습실 리스트 조회
-    Page<PracticeRoomResponseDto.GetResponseDto> getPracticeRoomList(PageRequestDto request);
+    PageResponseDto<PracticeRoomResponseDto.GetResponseDto> getPracticeRoomList(PageRequestDto request);
 }

--- a/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomServiceImpl.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/service/PracticeRoomServiceImpl.java
@@ -113,11 +113,17 @@ public class PracticeRoomServiceImpl implements PracticeRoomService {
 
     //연습실 목록 조회
     @Override
-    public Page<PracticeRoomResponseDto.GetResponseDto> getPracticeRoomList(PageRequestDto request) {
+    public PageResponseDto<PracticeRoomResponseDto.GetResponseDto> getPracticeRoomList(PageRequestDto request) {
         try {
             Pageable pageable = request.toPageable();
             Page<PracticeRoom> practiceRoomPage = practiceRoomRepository.findAllPracticeRoom(pageable);
-            return practiceRoomPage.map(PracticeRoomResponseDto.GetResponseDto::from); // 메서드 레퍼런스 사용
+
+            // PracticeRoom 엔티티의 Page를 PracticeRoomResponseDto.GetResponseDto DTO의 Page로 변환,
+            // map() 메서드를 사용하여 각 PracticeRoom 객체를 PracticeRoomResponseDto.GetResponseDto 객체로 변환
+            Page<PracticeRoomResponseDto.GetResponseDto> practiceRoomDtoPage = practiceRoomPage.map(PracticeRoomResponseDto.GetResponseDto::from);
+
+            // PageResponseDto.from() 정적 팩토리 메서드를 사용하여 Page<DTO> 객체를 PageResponseDto<DTO> 객체로 변환
+            return PageResponseDto.from(practiceRoomDtoPage);
         } catch (Exception e) {
             log.error("getPracticeRoomList error: {}", e.getMessage());
             throw new PracticeRoomHandler(ErrorStatus.PRACTICEROOM_NOT_FOUND);


### PR DESCRIPTION
## 🔓closed #77

## #️⃣연관된 이슈
#77 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

`Page` 대신 `PageResponseDto`를 사용하여 페이징 데이터 수정
    불필요한 데이터 제거 (e.g., `sort`, `pageable` 상세 정보)
    필수 페이징 정보(전체 페이지, 현재 페이지, 전체/현재 데이터 수)와 데이터 목록만 포함

### 스크린샷 (선택)


