### PR TITLE
chore: 연습실 등록 API 비활성화

### DIFF
--- a/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomController.java
+++ b/src/main/java/com/umc7/ZIC/practiceRoom/controller/PracticeRoomController.java
@@ -40,18 +40,18 @@ public class PracticeRoomController {
 
     // Practice Room 관련 API
     //연습실 등록
-    @Operation(summary = "연습실을 등록할때 사용하는 API", description = "유저가 Owner 역할일때 본인의 연습실을 등록할 때 사용하는 API")
-    @PostMapping
-    public ApiResponse<PracticeRoomResponseDto.CreateResponseDto> createPracticeRoom(
-            @RequestBody @Valid PracticeRoomRequestDto.CreateRequestDto createRequest) {
-        if (jwtTokenProvider.resolveAccessToken().isEmpty()) {
-            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        Long userId = jwtTokenProvider.getUserIdFromToken();
-        PracticeRoomResponseDto.CreateResponseDto response = practiceRoomService.createPracticeRoom(createRequest, userId);
-        return ApiResponse.onSuccess(response);
-    }
+//    @Operation(summary = "연습실을 등록할때 사용하는 API", description = "유저가 Owner 역할일때 본인의 연습실을 등록할 때 사용하는 API")
+//    @PostMapping
+//    public ApiResponse<PracticeRoomResponseDto.CreateResponseDto> createPracticeRoom(
+//            @RequestBody @Valid PracticeRoomRequestDto.CreateRequestDto createRequest) {
+//        if (jwtTokenProvider.resolveAccessToken().isEmpty()) {
+//            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
+//        }
+//
+//        Long userId = jwtTokenProvider.getUserIdFromToken();
+//        PracticeRoomResponseDto.CreateResponseDto response = practiceRoomService.createPracticeRoom(createRequest, userId);
+//        return ApiResponse.onSuccess(response);
+//    }
 
     //연습실 수정
     @PatchMapping("/{id}")


### PR DESCRIPTION
## 🔓closed #issue (#뒤에 issue 제거 후 이슈 번호 붙여주세요)

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

현재 대여자 한 명당 연습실 하나만 등록 가능 및 가입시 연습실 바로 생성되기 때문에
- 기존 연습실 등록 API (`createPracticeRoom`)를 통한 등록 방식은 비활성화

### 스크린샷 (선택)


